### PR TITLE
Capistranoの導入（修正）

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -15,7 +15,7 @@ set :rbenv_ruby, '2.5.1' #カリキュラム通りに進めた場合、2.5.1か2
 
 # どの公開鍵を利用してデプロイするか
 set :ssh_options, auth_methods: ['publickey'],
-                  keys: ['~/.ssh/jkey_mercari2019.pem']  ※例：~/.ssh/key_pem.pem
+                  keys: ['~/.ssh/jkey_mercari2019.pem']
 
 # プロセス番号を記載したファイルの場所
 set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }


### PR DESCRIPTION
WHAT
自動デプロイツールCapistranoを導入する。

WHY
シンタックスエラーが出たため、その修正を行った。