### PR TITLE
S3の導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+public/uploads/*
+config/secrets.yml

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,9 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
+gem 'carrierwave'
+gem 'fog-aws'
+
 group :production do
   gem 'unicorn', '5.4.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,10 @@ GEM
       sshkit (~> 1.3)
     capistrano3-unicorn (0.2.1)
       capistrano (~> 3.1, >= 3.1.0)
+    carrierwave (1.3.1)
+      activemodel (>= 4.0.0)
+      activesupport (>= 4.0.0)
+      mime-types (>= 1.16)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -69,12 +73,31 @@ GEM
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     erubis (2.7.0)
+    excon (0.64.0)
     execjs (2.7.0)
     ffi (1.11.1)
+    fog-aws (3.5.1)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.1.2)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    ipaddress (0.8.3)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     jquery-rails (4.3.5)
@@ -91,9 +114,13 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.0331)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    multi_json (1.13.1)
     mysql2 (0.5.2)
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
@@ -190,7 +217,9 @@ DEPENDENCIES
   capistrano-rails
   capistrano-rbenv
   capistrano3-unicorn
+  carrierwave
   coffee-rails (~> 4.2)
+  fog-aws
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,53 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  # storage :file
+  if Rails.env.development?
+    storage :file
+  elsif Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,13 +24,35 @@ set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
 set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }
 set :keep_releases, 5
 
+# secrets.yml用のシンボリックリンクを追加
+set :linked_files, %w{ config/secrets.yml }
+
 # デプロイ処理が終わった後、Unicornを再起動するための記述
 after 'deploy:publishing', 'deploy:restart'
 namespace :deploy do
   task :restart do
     invoke 'unicorn:restart'
   end
+
+  desc 'upload secrets.yml'
+  task :upload do
+    on roles(:app) do |host|
+      if test "[ ! -d #{shared_path}/config ]"
+        execute "mkdir -p #{shared_path}/config"
+      end
+      upload!('config/secrets.yml', "#{shared_path}/config/secrets.yml")
+    end
+  end
+  before :starting, 'deploy:upload'
+  after :finishing, 'deploy:cleanup'
 end
+
+set :default_env, {
+  rbenv_root: "/usr/local/rbenv",
+  path: "/usr/local/rbenv/shims:/usr/local/rbenv/bin:$PATH",
+  AWS_ACCESS_KEY_ID: ENV["AWS_ACCESS_KEY_ID"],
+  AWS_SECRET_ACCESS_KEY: ENV["AWS_SECRET_ACCESS_KEY"]
+}
 
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,17 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+  config.storage = :fog
+  config.fog_provider = 'fog/aws'
+  config.fog_credentials = {
+    provider: 'AWS',
+    aws_access_key_id: Rails.application.secrets.aws_access_key_id,
+    aws_secret_access_key: Rails.application.secrets.aws_secret_access_key,
+    region: 'ap-northeast-1' #例 'ap-northeast-1'
+  }
+
+  config.fog_directory  = 'freemarket0622a-imagedir'
+  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/freemarket0622a-imagedir'
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,6 +11,7 @@
 # if you're sharing your code publicly.
 
 development:
+  secret_key_base: 78617f24192b70e44a75fb716ed8a2300a5cd9a5187277b0fb1d9ea34a1e1a48a26129c0a77a74121225f5394d991c2140402d50fc4826709217cf0163e49c38
   secret_key_base: ~~~~~~~~
   aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
   aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,13 +12,11 @@
 
 development:
   secret_key_base: 78617f24192b70e44a75fb716ed8a2300a5cd9a5187277b0fb1d9ea34a1e1a48a26129c0a77a74121225f5394d991c2140402d50fc4826709217cf0163e49c38
-  secret_key_base: ~~~~~~~~
   aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
   aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
 
 test:
   secret_key_base: fc2dcfbc0f14f4c47b2bf0eb78eed6e79b84507a1cb1601935b008d2466157eca8806d7a3857b3d718afef426f7c27c9a620aff2de3a98e7acabd45d48b49da1
-  secret_key_base: ~~~~~~~~
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -11,12 +11,16 @@
 # if you're sharing your code publicly.
 
 development:
-  secret_key_base: 78617f24192b70e44a75fb716ed8a2300a5cd9a5187277b0fb1d9ea34a1e1a48a26129c0a77a74121225f5394d991c2140402d50fc4826709217cf0163e49c38
+  secret_key_base: ~~~~~~~~
+  aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
+  aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
 
 test:
-  secret_key_base: fc2dcfbc0f14f4c47b2bf0eb78eed6e79b84507a1cb1601935b008d2466157eca8806d7a3857b3d718afef426f7c27c9a620aff2de3a98e7acabd45d48b49da1
+  secret_key_base: ~~~~~~~~
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
+  aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -16,6 +16,7 @@ development:
   aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
 
 test:
+  secret_key_base: fc2dcfbc0f14f4c47b2bf0eb78eed6e79b84507a1cb1601935b008d2466157eca8806d7a3857b3d718afef426f7c27c9a620aff2de3a98e7acabd45d48b49da1
   secret_key_base: ~~~~~~~~
 
 # Do not keep production secrets in the repository,


### PR DESCRIPTION
WHAT
画像のアップロード先をS3にする。

WHY
画像をWEBアプリケーションのサーバーに保存すると容量が圧迫されるので、AWSのS3に保存先を確保し、そちらにアップロードされるようにする。