### PR TITLE
自動デプロイのエラー原因を探るための切り分け(item.rb)

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,5 @@
 class Item < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
   has_many :item_images
   belongs_to :user
   has_many :users, through: :users_items


### PR DESCRIPTION
WHAT
自動デプロイのエラー原因を探るための切り分け。

WHY
"NoMethodError: undefined method `has_many' for Brand:Class"
自動デプロイで上記エラーが出る原因がアソシエーションの記述の仕方（belongs_to_active_hash :brand）ではないかと仮定し、item.rbに下記の一文を記述し、確認するため。
extend ActiveHash::Associations::ActiveRecordExtensions