### PR TITLE
自動デプロイのエラー原因を探るための切り分け２(item.rb)

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,11 +5,11 @@ class Item < ApplicationRecord
   has_many :users, through: :users_items
   has_many :users, through: :likes
   belongs_to :category
-  belongs_to_active_hash :size
-  belongs_to_active_hash :status
-  belongs_to_active_hash :brand
-  belongs_to_active_hash :delivery_fee_payer
-  belongs_to_active_hash :delivery_method
-  belongs_to_active_hash :prefecture
-  belongs_to_active_hash :shipping_day
+  belongs_to :size
+  belongs_to :status
+  belongs_to :brand
+  belongs_to :delivery_fee_payer
+  belongs_to :delivery_method
+  belongs_to :prefecture
+  belongs_to :shipping_day
 end


### PR DESCRIPTION
WHAT
自動デプロイのエラー原因を探るための切り分け。

WHY
"NoMethodError: undefined method `has_many' for Brand:Class"
自動デプロイで上記エラーが出る原因がアソシエーションの記述の仕方ではないかと仮定し、
belongs_to_active_hash　→　belongs_to
と記述を変更し、確認するため。
