### PR TITLE
自動デプロイのエラー原因を探るための切り分け3(item.rb) 

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,7 +7,7 @@ class Item < ApplicationRecord
   belongs_to :category
   belongs_to :size
   belongs_to :status
-  belongs_to :brand
+  belongs_to :brand, optional: true
   belongs_to :delivery_fee_payer
   belongs_to :delivery_method
   belongs_to :prefecture


### PR DESCRIPTION
WHAT
自動デプロイのエラー原因を探るための切り分け。

WHY
"NoMethodError: undefined method `has_many' for Brand:Class"
自動デプロイで上記エラーが出る原因がアソシエーションの記述の仕方ではないかと仮定し、
belongs_to :brand　→　belongs_to :brand, optional: true
と記述を変更し、確認するため。