### PR TITLE
自動デプロイのエラー原因を探るための切り分け(delivery_fee_payer.rb)

### DIFF
--- a/app/models/delivery_fee_payer.rb
+++ b/app/models/delivery_fee_payer.rb
@@ -1,7 +1,7 @@
 class DeliveryFeePayer < ActiveHash::Base
   field :delivery_fee_payer
-  create id: 1, delivery_fee_payer: '送料込み(出品者負担)'
-  create id: 2, delivery_fee_payer: '着払い(購入者負担)'
+  create :id => 1, :delivery_fee_payer => '送料込み(出品者負担)'
+  create :id => 2, :delivery_fee_payer => '着払い(購入者負担)'
 
   has_many :items
 end


### PR DESCRIPTION
WHAT
自動デプロイのエラー原因を探るための切り分け。

WHY
"NoMethodError: undefined method `has_many' for DeliveryFeePayer:Class"
自動デプロイで上記エラーが出る原因がアロー記法ではないことが原因ではないかと仮定し、下記のように変更し検証するため。
create id: 1, delivery_fee_payer: '送料込み(出品者負担)'
↓↓↓
create :id => 1, :delivery_fee_payer => '送料込み(出品者負担)'
