### PR TITLE
自動デプロイのエラー原因を探るための切り分け２(delivery_fee_payer.rb) 

### DIFF
--- a/app/models/delivery_fee_payer.rb
+++ b/app/models/delivery_fee_payer.rb
@@ -1,7 +1,8 @@
 class DeliveryFeePayer < ActiveHash::Base
+  include ActiveHash::Associations
   field :delivery_fee_payer
-  create :id => 1, :delivery_fee_payer => '送料込み(出品者負担)'
-  create :id => 2, :delivery_fee_payer => '着払い(購入者負担)'
+  create id: 1, delivery_fee_payer: '送料込み(出品者負担)'
+  create id: 2, delivery_fee_payer: '着払い(購入者負担)'
 
   has_many :items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,7 @@ class Item < ApplicationRecord
   belongs_to :size
   belongs_to :status
   belongs_to :brand, optional: true
-  belongs_to :delivery_fee_payer
+  belongs_to_active_hash :delivery_fee_payer
   belongs_to :delivery_method
   belongs_to :prefecture
   belongs_to :shipping_day


### PR DESCRIPTION
WHAT
自動デプロイのエラー原因を探るための切り分け。

WHY
"NoMethodError: undefined method `has_many' for DeliveryFeePayer:Class"
自動デプロイで上記エラーが出る原因が、下記記述がないことが原因ではないかと仮定し、検証するため。
include ActiveHash::Associations