### PR TITLE
ActiveHashのアソシエーションの修正

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,4 +3,7 @@ class Category < ApplicationRecord
   belongs_to :first_category
   belongs_to :second_category
   belongs_to :third_category
+
+  has_many :sizes_categories
+  has_many :sizes, through: :sizes_categories
 end

--- a/app/models/delivery_method.rb
+++ b/app/models/delivery_method.rb
@@ -9,6 +9,4 @@ class DeliveryMethod < ActiveHash::Base
   create id: 7, delivery_method: 'ゆうパック'
   create id: 8, delivery_method: 'クリックポスト'
   create id: 9, delivery_method: 'ゆうパケット'
-
-  has_many :items
 end

--- a/app/models/evaluation.rb
+++ b/app/models/evaluation.rb
@@ -3,7 +3,4 @@ class Evaluation < ActiveHash::Base
   create id: 1, evaluation: '良い'
   create id: 2, evaluation: '普通'
   create id: 3, evaluation: '悪い'
-
-  has_many :users_evaluations
-  has_many :users, through: :users_evaluations
 end

--- a/app/models/first_category.rb
+++ b/app/models/first_category.rb
@@ -14,6 +14,4 @@ class FirstCategory < ActiveHash::Base
   create id: 12, first_category: '自動車・オートバイ'
   create id: 13, first_category: 'その他'
   create id: 14, first_category: 'カテゴリー一覧'
-
-  has_many :categories
 end

--- a/app/models/second_category.rb
+++ b/app/models/second_category.rb
@@ -138,8 +138,6 @@ class SecondCategory < ActiveHash::Base
   create id: 136, second_category: '文房具/事務用品'
   create id: 137, second_category: '事務/店舗用品'
   create id: 138, second_category: 'その他'
-
-  has_many :categories
 end
 
 

--- a/app/models/shipping_day.rb
+++ b/app/models/shipping_day.rb
@@ -3,6 +3,4 @@ class ShippingDay < ActiveHash::Base
   create id: 1, shipping_day: '1~2日で発送'
   create id: 2, shipping_day: '2~3日で発送'
   create id: 3, shipping_day: '4~7日で発送'
-
-  has_many :items
 end

--- a/app/models/size.rb
+++ b/app/models/size.rb
@@ -6,7 +6,4 @@ class Size < ActiveHash::Base
   create id: 4, size: '25.0'
   create id: 5, size: '26.0'
   create id: 6, size: '27.0'
-
-  has_many :items
-  belongs_to :category, through sizes_categories
 end

--- a/app/models/sizes_category.rb
+++ b/app/models/sizes_category.rb
@@ -1,4 +1,5 @@
 class SizesCategory < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :size
   belongs_to :category
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -6,6 +6,4 @@ class Status < ActiveHash::Base
   create id: 4, status: 'やや傷や汚れあり'
   create id: 5, status: '傷や汚れあり'
   create id: 6, status: '全体的に状態が悪い'
-
-  has_many :items
 end

--- a/app/models/third_category.rb
+++ b/app/models/third_category.rb
@@ -777,6 +777,4 @@ class ThirdCategory < ActiveHash::Base
   create id: 775, third_category: '店舗用品'
   create id: 776, third_category: 'OA機器'
   create id: 777, third_category: 'ラッピング/包装'
-
-  has_many :categories
 end

--- a/app/models/user_detail.rb
+++ b/app/models/user_detail.rb
@@ -1,5 +1,5 @@
 class UserDetail < ApplicationRecord
-
+  extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :user
-  belongs_to_active_hash :prefecture
+  belongs_to :prefecture
 end

--- a/app/models/users_evaluation.rb
+++ b/app/models/users_evaluation.rb
@@ -1,4 +1,5 @@
 class UsersEvaluation < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :user
-  belongs_to_active_hash :evaluation
+  belongs_to :evaluation
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,11 +39,29 @@ ActiveRecord::Schema.define(version: 20190809082943) do
   end
 
   create_table "items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.text     "item_title",  limit: 65535, null: false
-    t.text     "description", limit: 65535, null: false
-    t.integer  "price",                     null: false
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.text     "item_title",            limit: 65535, null: false
+    t.text     "description",           limit: 65535, null: false
+    t.integer  "category_id",                         null: false
+    t.integer  "size_id",                             null: false
+    t.integer  "brand_id",                            null: false
+    t.integer  "status_id",                           null: false
+    t.integer  "delivery_fee_payer_id",               null: false
+    t.integer  "delivery_method_id",                  null: false
+    t.integer  "prefecture_id",                       null: false
+    t.integer  "shipping_day_id",                     null: false
+    t.integer  "price",                               null: false
+    t.integer  "user_id",                             null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+    t.index ["brand_id"], name: "index_items_on_brand_id", using: :btree
+    t.index ["category_id"], name: "index_items_on_category_id", using: :btree
+    t.index ["delivery_fee_payer_id"], name: "index_items_on_delivery_fee_payer_id", using: :btree
+    t.index ["delivery_method_id"], name: "index_items_on_delivery_method_id", using: :btree
+    t.index ["prefecture_id"], name: "index_items_on_prefecture_id", using: :btree
+    t.index ["shipping_day_id"], name: "index_items_on_shipping_day_id", using: :btree
+    t.index ["size_id"], name: "index_items_on_size_id", using: :btree
+    t.index ["status_id"], name: "index_items_on_status_id", using: :btree
+    t.index ["user_id"], name: "index_items_on_user_id", using: :btree
   end
 
   create_table "likes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
WHAT
自動デプロイのエラー原因となるActiveHashのアソシエーションの修正。

WHY
"NoMethodError: undefined method has_many' for DeliveryFeePayer:Class" 
検証の結果、自動デプロイで上記エラーが出る原因が、'has_many'の記述がある事と判明したため、ActiveHashファイルを修正するため。