### PR TITLE
itemsテーブルのカラムのNOT NULL制約の変更

### DIFF
--- a/db/migrate/20190825062201_change_column_to_allow_null.rb
+++ b/db/migrate/20190825062201_change_column_to_allow_null.rb
@@ -1,0 +1,11 @@
+class ChangeColumnToAllowNull < ActiveRecord::Migration[5.0]
+  def up
+    change_column :items, :size_id,:integer, null: true
+    change_column :items, :brand_id,:integer, null: true
+  end
+
+  def down
+    change_column :items, :size_id,:integer, null: false
+    change_column :items, :brand_id,:integer, null: false
+  end
+end


### PR DESCRIPTION
WHAT
itemsテーブルのカラムのNOT NULL制約の変更。

WHY
サイズやブランドのない商品を出品する際に、値がnullでも登録できるようにするため、itemsカラムのsize_id及びbrand_idを「null: true」に変更する。

