### PR TITLE
itemsテーブルのカラムのNOT NULL制約の変更（２）

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190809082943) do
+ActiveRecord::Schema.define(version: 20190825062201) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "prefecture_id"
@@ -42,8 +42,8 @@ ActiveRecord::Schema.define(version: 20190809082943) do
     t.text     "item_title",            limit: 65535, null: false
     t.text     "description",           limit: 65535, null: false
     t.integer  "category_id",                         null: false
-    t.integer  "size_id",                             null: false
-    t.integer  "brand_id",                            null: false
+    t.integer  "size_id"
+    t.integer  "brand_id"
     t.integer  "status_id",                           null: false
     t.integer  "delivery_fee_payer_id",               null: false
     t.integer  "delivery_method_id",                  null: false


### PR DESCRIPTION
WHAT
itemsテーブルのカラムのNOT NULL制約の変更。

WHY
migrationファイルのみpushしてしまい、schema.rbをpushし忘れたため。