### PR TITLE
商品の状態遷移をaasmで管理する

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,25 @@
 class Item < ApplicationRecord
+  include AASM
+
+  aasm do
+    # 状態の定義
+    state :waiting, :initial => true
+    state :wip, :done
+
+    # イベントの定義
+    event :run do
+      # 遷移の定義
+      transitions :from => :waiting, :to => :wip
+    end
+
+    event :finish do
+      transitions :from => :wip, :to => :done
+    end
+
+    event :wait do
+      transitions :from => [:wip, :done], :to => :waiting
+    end
+  end
   extend ActiveHash::Associations::ActiveRecordExtensions
   has_many :item_images
   belongs_to :user

--- a/db/migrate/20190831092322_add_aasm_state_to_items.rb
+++ b/db/migrate/20190831092322_add_aasm_state_to_items.rb
@@ -1,0 +1,5 @@
+class AddAasmStateToItems < ActiveRecord::Migration[5.0]
+  def change
+    add_column :items, :aasm_state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190825062201) do
+ActiveRecord::Schema.define(version: 20190831092322) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "prefecture_id"
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 20190825062201) do
     t.integer  "user_id",                             null: false
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
+    t.string   "aasm_state"
     t.index ["brand_id"], name: "index_items_on_brand_id", using: :btree
     t.index ["category_id"], name: "index_items_on_category_id", using: :btree
     t.index ["delivery_fee_payer_id"], name: "index_items_on_delivery_fee_payer_id", using: :btree


### PR DESCRIPTION
WHAT
商品の状態遷移をaasmで管理する。

WHY
商品の出品状態の遷移を制御する為に、models/items.rbに状態・イベント・遷移を定義し、itemsテーブルに状態管理用のカラムを追加するため。