### PR TITLE
プロフィールページの修正

### DIFF
--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -16,7 +16,7 @@
       = f.submit '変更する'
 
 .sellbutton
-  = link_to '' do
+  = link_to new_item_path do
     %p 出品
     =fa_icon "camera"
 = render 'layouts/footer'


### PR DESCRIPTION
WHAT
プロフィールページを修正。

WHY
商品出品のリンク先を設定するため。