### PR TITLE
item_image.rbの修正

### DIFF
--- a/app/models/item_image.rb
+++ b/app/models/item_image.rb
@@ -1,5 +1,5 @@
 class ItemImage < ApplicationRecord
   belongs_to :item
 
-  mount_uploader :image_url, ImageUploader
+  #mount_uploader :image_url, ImageUploader
 end


### PR DESCRIPTION
WHAT
item_image.rbを修正する。

WHY
画像が非表示になる不具合を修正するため。
