### PR TITLE
Make destroy function

### DIFF
--- a/app/assets/stylesheets/modules/item_parts/_item-detail.scss
+++ b/app/assets/stylesheets/modules/item_parts/_item-detail.scss
@@ -237,7 +237,7 @@
   }
 }
 
-.item-buy-btn {
+.item-btn {
   width: 620px;
   height: 60px;
   line-height: 60px;
@@ -246,14 +246,21 @@
   font-weight: bold;
   font-size: 26px;
   color: #fff;
-  &__gray {
+  &__buy__gray {
     background-color: gray;
   }
-  &__red {
+  &__buy__red {
     a {
       display: block;
       background: #ea352d;
       color: #fff;
+    }
+  }
+  &__destroy__gray {
+    background-color: gray;
+    a {
+      color: #fff;
+      font-size: 16px;
     }
   }
 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -73,6 +73,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
+    item = Item.find(params[:id])
+    item.destroy if item.user_id == current_user.id
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -27,7 +27,7 @@ class Item < ApplicationRecord
     end
   end
   extend ActiveHash::Associations::ActiveRecordExtensions
-  has_many :item_images
+  has_many :item_images, dependent: :destroy
   belongs_to :user
   has_many :users, through: :users_items
   has_many :users, through: :likes

--- a/app/views/items/destroy.html.haml
+++ b/app/views/items/destroy.html.haml
@@ -1,0 +1,5 @@
+.contents.row
+  .success
+    %h3
+      削除が完了しました。
+    %a.btn{:href => "/"} トップページへ戻る

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -74,13 +74,24 @@
           （税込）
         %span.item-detail-price__shipping-fee
           = "#{@item.delivery_fee_payer.delivery_fee_payer}".sub(/\(.*/, '')
-      .item-buy-btn
-        - if @item.aasm_state == nil || @item.aasm_state == 'waiting'
-          .item-buy-btn__red
-            = link_to '購入画面に進む', transaction_path(params[:id])
-        -else
-          .item-buy-btn__gray
-            売り切れました
+      -# .item-buy-btn
+      -#   - if @item.aasm_state == nil || @item.aasm_state == 'waiting'
+      -#     .item-buy-btn__red
+      -#       = link_to '購入画面に進む', transaction_path(params[:id])
+      -#   -else
+      -#     .item-buy-btn__gray
+      -#       売り切れました
+      .item-btn
+        - if @item.user_id == current_user.id
+          .item-btn__destroy__gray
+            = link_to 'この商品を削除する', "/items/#{@item.id}", method: :delete
+        - else
+          - if @item.aasm_state == nil || @item.aasm_state == 'waiting'
+            .item-btn__buy__red
+              = link_to '購入画面に進む', transaction_path(params[:id])
+          -else
+            .item-btn__buy__gray
+              売り切れました
       .item-description
         %p
           = @item.description


### PR DESCRIPTION
# What
商品削除機能の実装。
・item.rb
→外部キーを持つテーブルのdestroyアクションを動かすためのコード記載。

・items_controller.rb
→item出品者とログインユーザーが同じ場合にdestroyアクションを動かすことができるためのコントローラー設定。

・destroy.html.haml
→商品削除した後の遷移ページ（削除確認）の作成。

・show.html.haml
→ログインユーザーと商品出品者が同じ場合に商品削除ボタンが表示され、異なる場合に商品購入ボタンが表示されるようにコードを記載、それに伴いクラス名も微修正しています。（念のためコメントアウトで元のコードを残しています。）

・_item-detail.scss
→show.html.hamlの変更に伴うコードの微修正を加えています。

# Why
必須機能のため。