### PR TITLE
売却済み表示の実装

### DIFF
--- a/app/assets/stylesheets/modules/item_parts/_brandpage.scss
+++ b/app/assets/stylesheets/modules/item_parts/_brandpage.scss
@@ -56,30 +56,55 @@
             height: 200px;
             margin-bottom:25px;
           }
-          div {
-            width:174px;
-            margin:0 auto;
-            text-decoration: none;
-            div {
-              display: inline-block;
-              margin-bottom:15px;
-              line-height:1.6em;
-            }
-            .price {
-              float:left;
-              font-weight: bold;
-            }
-            .likes {
-              float:right;
-              i {
-                font-size:1.3em;
-                color: #ccc;
-              }
-            }
+          &-sold {
+            width: 190px;
+            position: relative;
+            top: -225px;
+          }
+          &-sold::before {
+            content: "";
+            top: 0;
+            left: 0;
+            border-bottom: 100px solid transparent;
+            border-left: 100px solid #c12748; /* ラベルの色はここで変更 */
+            position: absolute;
+            z-index: 100;
+          }
+          &-sold::after {
+            content: "SOLD";
+            display: block;
+            top: 20px;
+            transform: rotate(-45deg);
+            color: #fff; /* 文字色はここで変更 */
+            font-weight:bold;
+            font-size: 24px;
+            left: 0;
+            position: absolute;
+            z-index: 101;
           }
         }
         &-frame:last-child {
           margin-right: 0;
+        }
+        &__detail {
+          width:174px;
+          margin:0 auto;
+          text-decoration: none;
+          .title {
+            margin-bottom:15px;
+            line-height:1.6em;
+          }
+          .price {
+            float:left;
+            font-weight: bold;
+          }
+          .likes {
+            float:right;
+            i {
+              font-size:1.3em;
+              color: #ccc;
+            }
+          }
         }
       }
       .contents__all-items {

--- a/app/assets/stylesheets/modules/item_parts/_categorypage.scss
+++ b/app/assets/stylesheets/modules/item_parts/_categorypage.scss
@@ -56,30 +56,55 @@
             height: 200px;
             margin-bottom:25px;
           }
-          div {
-            width:174px;
-            margin:0 auto;
-            text-decoration: none;
-            div {
-              display: inline-block;
-              margin-bottom:15px;
-              line-height:1.6em;
-            }
-            .price {
-              float:left;
-              font-weight: bold;
-            }
-            .likes {
-              float:right;
-              i {
-                font-size:1.3em;
-                color: #ccc;
-              }
-            }
+          &-sold {
+            width: 190px;
+            position: relative;
+            top: -225px;
+          }
+          &-sold::before {
+            content: "";
+            top: 0;
+            left: 0;
+            border-bottom: 100px solid transparent;
+            border-left: 100px solid #c12748; /* ラベルの色はここで変更 */
+            position: absolute;
+            z-index: 100;
+          }
+          &-sold::after {
+            content: "SOLD";
+            display: block;
+            top: 20px;
+            transform: rotate(-45deg);
+            color: #fff; /* 文字色はここで変更 */
+            font-weight:bold;
+            font-size: 24px;
+            left: 0;
+            position: absolute;
+            z-index: 101;
           }
         }
         &-frame:last-child {
           margin-right: 0;
+        }
+        &__detail {
+          width:174px;
+          margin:0 auto;
+          text-decoration: none;
+          .title {
+            margin-bottom:15px;
+            line-height:1.6em;
+          }
+          .price {
+            float:left;
+            font-weight: bold;
+          }
+          .likes {
+            float:right;
+            i {
+              font-size:1.3em;
+              color: #ccc;
+            }
+          }
         }
       }
       .contents__all-items {

--- a/app/assets/stylesheets/modules/item_parts/_item-detail.scss
+++ b/app/assets/stylesheets/modules/item_parts/_item-detail.scss
@@ -58,6 +58,33 @@
   float: left;
   &__main-photo {
     overflow: hidden;
+    &-sold {
+      width: 300px;
+      height: 300px;
+      position: relative;
+      top: -300px;
+    }
+    &-sold::before {
+      content: "";
+      top: 0;
+      left: 0;
+      border-bottom: 116px solid transparent;
+      border-left: 116px solid #c12748; /* ラベルの色はここで変更 */
+      position: absolute;
+      z-index: 100;
+    }
+    &-sold::after {
+      content: "SOLD";
+      display: block;
+      top: 25px;
+      transform: rotate(-45deg);
+      color: #fff; /* 文字色はここで変更 */
+      font-weight:bold;
+      font-size: 28px;
+      left: 0;
+      position: absolute;
+      z-index: 101;
+    }
     img {
       min-width: 300px;
       max-width: 300px;
@@ -559,25 +586,52 @@
       height: 214px;
       margin-bottom:25px;
     }
-    div {
-      width:174px;
-      margin:0 auto;
-      text-decoration: none;
-      div {
-        display: inline-block;
-        margin-bottom:15px;
-        line-height:1.6em;
-      }
-      .price {
-        float:left;
-        font-weight: bold;
-      }
-      .likes {
-        float:right;
-        i {
-          font-size:1.3em;
-          color: #ccc;
-        }
+    &-sold {
+      width: 214px;
+      // height: 214px;
+      position: relative;
+      top: -239px;
+    }
+    &-sold::before {
+      content: "";
+      top: 0;
+      left: 0;
+      border-bottom: 100px solid transparent;
+      border-left: 100px solid #c12748; /* ラベルの色はここで変更 */
+      position: absolute;
+      z-index: 100;
+    }
+    &-sold::after {
+      content: "SOLD";
+      display: block;
+      top: 20px;
+      transform: rotate(-45deg);
+      color: #fff; /* 文字色はここで変更 */
+      font-weight:bold;
+      font-size: 24px;
+      left: 0;
+      position: absolute;
+      z-index: 101;
+    }
+  }
+  &__detail {
+    width:174px;
+    margin:0 auto;
+    text-decoration: none;
+    position: relative;
+    .title {
+      margin-bottom:15px;
+      line-height:1.6em;
+    }
+    .price {
+      float:left;
+      font-weight: bold;
+    }
+    .likes {
+      float:right;
+      i {
+        font-size:1.3em;
+        color: #ccc;
       }
     }
   }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -54,7 +54,7 @@ class ItemsController < ApplicationController
 
   def create # 商品出品完了
     @item = Item.new(item_params)
-    @item.user_id = current_user.id    
+    @item.user_id = current_user.id
     if @item.save
       redirect_to root_path
     end

--- a/app/views/items/brand.html.haml
+++ b/app/views/items/brand.html.haml
@@ -13,8 +13,10 @@
         - @brand_items.each do |item|
           = link_to item_path(item.id), class: 'contents__items-frame' do
             = image_tag(item.item_images[0].image_url, width: '135', alt: '商品画像')
-            %div
-              %div
+            - if item.aasm_state == 'done'
+              %p.contents__items-frame-sold
+            .contents__items__detail
+              %p.title
                 = item.item_title
               %span.price 
                 ¥

--- a/app/views/items/category.html.haml
+++ b/app/views/items/category.html.haml
@@ -17,8 +17,10 @@
           - @first_items.reverse!.each do |item|
             = link_to item_path(item.id), class: 'contents__items-frame' do
               = image_tag(item.item_images[0].image_url, width: '135', alt: '商品画像')
-              %div
-                %div
+              - if item.aasm_state == 'done'
+                %p.contents__items-frame-sold
+              .contents__items__detail
+                %p.title
                   = item.item_title
                 %span.price 
                   ¥
@@ -29,8 +31,10 @@
           - @second_items.reverse!.each do |item|
             = link_to item_path(item.id), class: 'contents__items-frame' do
               = image_tag(item.item_images[0].image_url, width: '135', alt: '商品画像')
-              %div
-                %div
+              - if item.aasm_state == 'done'
+                %p.contents__items-frame-sold
+              .contents__items__detail
+                %p.title
                   = item.item_title
                 %span.price 
                   ¥
@@ -41,8 +45,10 @@
           - @third_items.reverse!.each do |item|
             = link_to item_path(item.id), class: 'contents__items-frame' do
               = image_tag(item.item_images[0].image_url, width: '135', alt: '商品画像')
-              %div
-                %div
+              - if item.aasm_state == 'done'
+                %p.contents__items-frame-sold
+              .contents__items__detail
+                %p.title
                   = item.item_title
                 %span.price 
                   ¥

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -8,6 +8,8 @@
         .item-content
           .item-content__main-photo
             = image_tag(@item.item_images[0].image_url, width: '135', alt: '商品画像')
+            - if @item.aasm_state == 'done'
+              .item-content__main-photo-sold
           - @item.item_images.each_with_index do |image, i|
             - if i > 0 and i < 4
               .item-content__sub-photo
@@ -74,24 +76,17 @@
           （税込）
         %span.item-detail-price__shipping-fee
           = "#{@item.delivery_fee_payer.delivery_fee_payer}".sub(/\(.*/, '')
-      -# .item-buy-btn
-      -#   - if @item.aasm_state == nil || @item.aasm_state == 'waiting'
-      -#     .item-buy-btn__red
-      -#       = link_to '購入画面に進む', transaction_path(params[:id])
-      -#   -else
-      -#     .item-buy-btn__gray
-      -#       売り切れました
       .item-btn
         - if @item.user_id == current_user.id
           .item-btn__destroy__gray
             = link_to 'この商品を削除する', "/items/#{@item.id}", method: :delete
         - else
-          - if @item.aasm_state == nil || @item.aasm_state == 'waiting'
-            .item-btn__buy__red
-              = link_to '購入画面に進む', transaction_path(params[:id])
-          -else
+          - if @item.aasm_state == 'done'
             .item-btn__buy__gray
               売り切れました
+          -else
+            .item-btn__buy__red
+              = link_to '購入画面に進む', transaction_path(params[:id])
       .item-description
         %p
           = @item.description
@@ -180,8 +175,10 @@
         - if 0 <= i and i <= 2
           = link_to item_path(item.id), class: 'contents__items-frame' do
             = image_tag(item.item_images[0].image_url, alt: '商品画像')
-            %div
-              %div
+            - if item.aasm_state == 'done'
+              %p.contents__items-frame-sold
+            .contents__items__detail
+              %p.title
                 = item.item_title
               %span.price
                 = number_to_currency(item.price, unit: "￥", precision: 0)
@@ -193,8 +190,10 @@
         - if 3 <= i and i <= 5
           = link_to item_path(item.id), class: 'contents__items-frame' do
             = image_tag(item.item_images[0].image_url, alt: '商品画像')
-            %div
-              %div
+            - if item.aasm_state == 'done'
+              %p.contents__items-frame-sold
+            .contents__items__detail
+              %p.title
                 = item.item_title
               %span.price
                 = number_to_currency(item.price, unit: "￥", precision: 0)
@@ -217,27 +216,31 @@
           - if 0 <= i and i <= 2
             = link_to item_path(item.id), class: 'contents__items-frame' do
               = image_tag(item.item_images[0].image_url, alt: '商品画像')
-              %div
-                %div
+              - if item.aasm_state == 'done'
+                %p.contents__items-frame-sold
+              .contents__items__detail
+                %p.title
                   = item.item_title
                 %span.price
                   = number_to_currency(item.price, unit: "￥", precision: 0)
                 %span.likes
                   =fa_icon "heart-o"
-                  100
+                  12
       - else
         - @allitems.where(brand_id: @item.brand_id).where(category_id: @item.category_id).each_with_index do |item, i|
           - if 1 <= i and i <= 3
             = link_to item_path(item.id), class: 'contents__items-frame' do
               = image_tag(item.item_images[0].image_url, alt: '商品画像')
-              %div
-                %div
+              - if item.aasm_state == 'done'
+                %p.contents__items-frame-sold
+              .contents__items__detail
+                %p.title
                   = item.item_title
                 %span.price
                   = number_to_currency(item.price, unit: "￥", precision: 0)
                 %span.likes
                   =fa_icon "heart-o"
-                  100
+                  12
 .main-visual
 
 = render "layouts/footer"


### PR DESCRIPTION
WHAT
売却済み表示を実装する。

WHY
商品詳細、カテゴリーからの商品一覧、ブランド名からの商品一覧の売却済みの商品に”SOLD”の赤タグを表示させるため。


