### PR TITLE
商品状態遷移の修正およびトップページリンク修正

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -2,7 +2,6 @@ class TransactionsController < ApplicationController
   before_action :set_item
   before_action :set_card
   require 'payjp'
-  require 'aasm'
 
   def show
     if @card.blank?
@@ -15,7 +14,9 @@ class TransactionsController < ApplicationController
     customer = Payjp::Customer.retrieve(@card.customer_id)
     #保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入
     @default_card_information = customer.cards.retrieve(@card.card_id)
-    @item.run!
+    if @item.aasm_state == 'waiting'
+      @item.run!
+    end
   end
 end
 

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -19,7 +19,7 @@
               %span.likes
                 100
       .contents__all-items
-        = link_to 'すべての商品を見る', ''
+        = link_to 'すべての商品を見る', category_item_path(1)
 
       %h2
         = link_to "#{@category2.first_category}新着アイテム", category_item_path(2)
@@ -37,7 +37,7 @@
                 =fa_icon "heart-o"
                 135
       .contents__all-items
-        = link_to 'すべての商品を見る', ''
+        = link_to 'すべての商品を見る', category_item_path(2)
 
       %h2
         = link_to "#{@category3.first_category}新着アイテム", category_item_path(3)
@@ -55,7 +55,7 @@
                 =fa_icon "heart-o"
                 135
       .contents__all-items
-        = link_to 'すべての商品を見る', ''
+        = link_to 'すべての商品を見る', category_item_path(3)
 
       %h2
         = link_to "#{@category4.first_category}新着アイテム", category_item_path(7)
@@ -73,7 +73,7 @@
                 =fa_icon "heart-o"
                 135
       .contents__all-items
-        = link_to 'すべての商品を見る', ''
+        = link_to 'すべての商品を見る', category_item_path(7)
 
     %section
       %h1.pickupbrand ピックアップブランド
@@ -95,7 +95,7 @@
                   =fa_icon "heart-o"
                   135
       .contents__all-items
-        = link_to 'すべての商品をみる'
+        = link_to 'すべての商品をみる', brand_item_path(49)
 
       %h2
         = link_to brand_item_path(50), alt: 'ルイヴィトン' do
@@ -115,7 +115,7 @@
                   =fa_icon "heart-o"
                   135
       .contents__all-items
-        = link_to 'すべての商品をみる'
+        = link_to 'すべての商品をみる', brand_item_path(50)
 
       %h2
         = link_to brand_item_path(52), alt: 'シュプリーム' do
@@ -135,7 +135,7 @@
                   =fa_icon "heart-o"
                   135
       .contents__all-items
-        = link_to 'すべての商品をみる'
+        = link_to 'すべての商品をみる', brand_item_path(52)
         
       %h2
         = link_to brand_item_path(51), alt: 'ナイキ' do
@@ -155,7 +155,7 @@
                   =fa_icon "heart-o"
                   135
       .contents__all-items
-        = link_to 'すべての商品をみる'
+        = link_to 'すべての商品をみる', brand_item_path(51)
 
 .main__foot-visual 
 .sellbutton


### PR DESCRIPTION
WHAT
商品状態遷移の修正およびトップページリンク修正。

WHY
商品状態遷移のエラー修正のためtransactions_controller.rbを修正し、トップページのリンクの修正を行うため。
