### PR TITLE
購入画面非表示の修正

### DIFF
--- a/app/assets/stylesheets/transaction/home.scss
+++ b/app/assets/stylesheets/transaction/home.scss
@@ -121,6 +121,22 @@ body {
         font-wight: bold;
         text-decoration: none;
       }
+      &__notbuy {
+        display: block;
+        width: 100%;
+        padding: 15px 0;
+        margin: 20px 0 0 0;
+        text-align: center;
+        background: #ccc;
+        font-size:14px;
+        letter-spacing: 1.1px;
+        color: #000;
+        font-wight: bold;
+        text-decoration: none;
+        &-not {
+          background: #ccc;
+        }
+      }
       &__app-install {
         margin: 10px 0 0 0;
         font-size:14px;

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -9,16 +9,12 @@ class TransactionsController < ApplicationController
       redirect_to controller: "card", action: "new"
       flash[:alert] = '購入にはクレジットカード登録が必要です'
     else
-    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-    #保管した顧客IDでpayjpから情報取得
-    customer = Payjp::Customer.retrieve(@card.customer_id)
-    #保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入
-    @default_card_information = customer.cards.retrieve(@card.card_id)
-    if @item.aasm_state == 'waiting'
-      @item.run!
+      get_payjp
+      if @item.aasm_state == 'waiting'
+        @item.run!
+      end
     end
   end
-end
 
   def pay
     Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
@@ -32,9 +28,7 @@ end
 
   def  done
     @item.finish!
-    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-    customer = Payjp::Customer.retrieve(@card.customer_id)
-    @default_card_information = customer.cards.retrieve(@card.card_id)
+    get_payjp
   end
 
   private
@@ -47,6 +41,30 @@ end
   def set_card
     @card = Card.find_by(user_id: current_user.id)
   end
+
+  def get_payjp
+    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+    #保管した顧客IDでpayjpから情報取得
+    customer = Payjp::Customer.retrieve(@card.customer_id)
+    #保管したカードIDでpayjpから情報取得、カード情報表示のためインスタンス変数に代入
+    @default_card_information = customer.cards.retrieve(@card.card_id)
+    @card_brand = @default_card_information.brand      
+    case @card_brand
+    when "Visa"
+      @card_src = "visa.svg"
+    when "JCB"
+      @card_src = "jcb.svg"
+    when "MasterCard"
+      @card_src = "master-card.svg"
+    when "American Express"
+      @card_src = "american_express.svg"
+    when "Saison Card"
+      @card_src = "saison-card.svg"
+    when "Diners Club"
+      @card_src = "dinersclub.svg"
+    when "Discover"
+      @card_src = "discover.svg"
+    end
+  end
+
 end
-
-

--- a/app/views/transactions/done.html.haml
+++ b/app/views/transactions/done.html.haml
@@ -28,7 +28,7 @@
         %li
           = "#{current_user.user_detail.prefecture.prefecture}#{current_user.user_detail.city}#{current_user.user_detail.address}"
         %li
-          ="#{current_user.user_detail.first_name}#{current_user.user_detail.family_name}"
+          ="#{current_user.user_detail.family_name}#{current_user.user_detail.first_name}"
       %p.main__inner__buyer
         支払い方法
       .main__inner__buyer-payment
@@ -38,7 +38,7 @@
           - exp_month = @default_card_information.exp_month.to_s
           - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
           = exp_month + " / " + exp_year
-        = image_tag('', width: '26', height: '22', alt: 'クレジットカード') 
+        = image_tag("credit-cards/#{@card_src}", width: '30', height: '24', alt: @card_brand)
       .lower
         .flow
           発送通知後の流れ

--- a/app/views/transactions/show.html.haml
+++ b/app/views/transactions/show.html.haml
@@ -21,12 +21,15 @@
           支払い金額
         %span
           = number_to_currency(@item.price, unit: "￥", precision: 0)
-      %p.main__inner__app-only
-        この商品はゆうゆうメルカリ便を利用しているため、アプリからのみ購入できます。
-      = form_tag(action: :pay, method: :post,) do
-        %button.main__inner__buy 購入する
-      %p.main__inner__app-install
-        アプリをお持ちでない方は以下よりインストールしてご利用いただけます。
+      - if @item.delivery_method_id == 2
+        %p.main__inner__app-only
+          この商品はゆうゆうメルカリ便を利用しているため、アプリからのみ購入できます。
+          %button.main__inner__notbuy{disabled: "disabled"} 購入する
+        %p.main__inner__app-install
+          アプリをお持ちでない方は以下よりインストールしてご利用いただけます。
+      - else
+        = form_tag(action: :pay, method: :post,) do
+          %button.main__inner__buy 購入する
       %p.main__inner__buyer
         配送先
       %ul.main__inner__buyer-address
@@ -35,7 +38,7 @@
         %li
           = "#{current_user.user_detail.prefecture.prefecture}#{current_user.user_detail.city}#{current_user.user_detail.address}"
         %li
-          ="#{current_user.user_detail.first_name}#{current_user.user_detail.family_name}"
+          ="#{current_user.user_detail.family_name} #{current_user.user_detail.first_name}"
       %p.main__inner__change
         = link_to '変更する', ""
       %p.main__inner__buyer
@@ -51,7 +54,7 @@
           - exp_month = @default_card_information.exp_month.to_s
           - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
           = exp_month + " / " + exp_year
-        = image_tag('', width: '26', height: '22', alt: 'クレジットカード')
+        = image_tag("credit-cards/#{@card_src}", width: '30', height: '24', alt: @card_brand)
         %p.main__inner__change
           = link_to '変更する', new_transaction_path
   %footer


### PR DESCRIPTION
WHAT
購入画面非表示の修正。

WHY
購入画面が表示できない状況の解消および購入画面にクレジットカード情報を表示させるため。
