### PR TITLE
商品詳細ページのリンクの修正

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -86,7 +86,7 @@
               売り切れました
           -else
             .item-btn__buy__red
-              = link_to '購入画面に進む', transaction_path(params[:id])
+              = link_to '購入画面に進む', transaction_path(params[:id]), method: :get
       .item-description
         %p
           = @item.description


### PR DESCRIPTION
WHAT
商品詳細ページのリンクの修正。

WHY
商品詳細ページのlink_toに、method: :getを明記するため。