### PR TITLE
routes.rbの修正

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -64,7 +64,4 @@ class CardsController < ApplicationController
       redirect_to action: "index"
   end
 
-  def show
-
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :transactions, only: [:index, :update, :show, :new] do
+  resources :transactions, only: [:show] do
     member do
       post 'pay' #購入
       get 'done' #購入後
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
       post 'pay', to: 'signup#pay'
     end
   end
-  resources :cards, only: [:index, :new, :show] do
+  resources :cards, only: [:index, :new] do
     collection do
       post 'pay', to: 'cards#pay'
       post 'delete', to: 'cards#delete'


### PR DESCRIPTION
WHAT
routes.rbを修正。

WHY
production.logに「No route matches {:action=>"new", :controller=>"card", :id=>"100"}」と記載があったため、不必要なルートを削除するため。
